### PR TITLE
Document alternating narrative arc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ Objectif : créer le premier livre 100% rédigé par une IA et faire évoluer ce
 - Chaque chapitre final est découpée en p `docs/chapitres_finaux/chapitre_{01..24}/part_{01..}.md` avec sa critique dans `docs/critiques/` et son analyse dans `docs/explications/`.
 - Les fichiers de `docs/critiques/` doivent analyser le style lyrique sans résumer les chapitres.
 - La cohérence narrative est primordiale.
+- Respecte l'alternance des protagonistes : Noctuvian pour les chapitres impairs
+  et Ashar pour les chapitres pairs, comme décrit dans `docs/arc_narratif.md`.
 - L'agent maintient le ton défini dans `docs/author-guide.md`.
 - Utilise `npm run compile:chapters` pour générer le manuscrit complet.
 - Si tu ne sais pas quoi faire : utilise le [fichier de roadmap](/docs/roadmap.md) avec des hypothèses d'action.

--- a/docs/arc_narratif.md
+++ b/docs/arc_narratif.md
@@ -1,0 +1,43 @@
+# Choix d'arc narratif alterne
+
+Ce document explique la nouvelle structure du manuscrit. Les chapitres alternent des points de vue distincts :
+- **Noctuvian** demeure le protagoniste des chapitres impairs.
+- **Ashar** devient le protagoniste des chapitres pairs, agissant dans le monde des hommes.
+
+Cette alternance permet de contrebalancer la dimension ésotérique de Noctuvian avec une approche plus tangible. Elle ancre le récit dans un double cheminement, chaque héros influençant l'autre à distance.
+
+## Récapitulation des chapitres
+
+| Numéro | Protagoniste principal |
+|-------:|-----------------------|
+| 1 | Noctuvian |
+| 2 | Ashar |
+| 3 | Noctuvian |
+| 4 | Ashar |
+| 5 | Noctuvian |
+| 6 | Ashar |
+| 7 | Noctuvian |
+| 8 | Ashar |
+| 9 | Noctuvian |
+|10 | Ashar |
+|11 | Noctuvian |
+|12 | Ashar |
+|13 | Noctuvian |
+|14 | Ashar |
+|15 | Noctuvian |
+|16 | Ashar |
+|17 | Noctuvian |
+|18 | Ashar |
+|19 | Noctuvian |
+|20 | Ashar |
+|21 | Noctuvian |
+|22 | Ashar |
+|23 | Noctuvian |
+|24 | Ashar |
+
+Les chapitres déjà rédigés se concentrent sur Noctuvian. Les chapitres dédiés à Ashar seront créés ou développés afin de respecter cette alternance. Chaque paire doit tisser des échos et des correspondances : un symbole rencontré par Ashar peut réapparaître dans la quête intérieure de Noctuvian, et inversement.
+
+## Motivation
+
+Ce découpage vise à maintenir l'engagement du lecteur en offrant un rythme plus équilibré. La science incarnée par Ashar complète la dimension mystique de Noctuvian. Ensemble, ils dévoilent peu à peu la lutte contre les alchimistes noirs dans deux réalités.
+

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,6 +5,7 @@ Umbranexus chronicles the creation of the first book fully written via AI. This 
 - [Knowledge Ethics](./knowledge-ethics.md)
 - [VitePress](./vitepress.md)
 - [Roadmap](./roadmap.md)
+- [Arc narratif alterné](./arc_narratif.md)
 - [LLM Authorship](./llm-authorship.md)
 - [Version PDF complète](./chapitres_finaux/compiled_book.pdf)
 - **Chapitres**

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,6 @@
 # Roadmap
 
 - Review every chapter for narrative respirations, ensuring each includes concrete scenes or dialogues.
+- Integrate the Ashar arc so that each even chapter features him as principal protagonist, according to `docs/arc_narratif.md`.
 - Verify that critiques reflect these narrative updates.
 - Ensure the compiled manuscript surpasses **300 pages** in length.


### PR DESCRIPTION
## Summary
- add documentation `arc_narratif.md` describing how chapters alternate between Noctuvian and Ashar
- reference the new arc in the roadmap
- link new documentation from the site index
- clarify protagonist alternation rule in AGENTS guidelines

## Testing
- `npm run compile:chapters`
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4e602e20832d9f8f19c86afeba59