### PR TITLE
fix compile script invocation

### DIFF
--- a/scripts/compile-chapters.js
+++ b/scripts/compile-chapters.js
@@ -152,3 +152,17 @@ export async function main() {
   await generateChapterFiles();
   await compileBook();
 }
+
+// Si le script est exécuté directement via `node scripts/compile-chapters.js`
+// (et non importé comme module), on lance la fonction main automatiquement.
+import { fileURLToPath } from 'url';
+
+const isDirectRun = process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+
+if (isDirectRun) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary
- ensure `npm run compile:chapters` actually compiles chapters

## Testing
- `npm test`
- `node scripts/compile-chapters.js`


------
https://chatgpt.com/codex/tasks/task_e_6863c7250710832db442b9b0ff906942